### PR TITLE
Remove specification of `stack.yaml` in `plain.hsfiles`

### DIFF
--- a/plain.hsfiles
+++ b/plain.hsfiles
@@ -37,16 +37,6 @@ import Reanimate.Builtin.Documentation
 main :: IO ()
 main = reanimate $ docEnv $ drawBox `parA` adjustDuration (*2) drawCircle
 
-{-# START_FILE stack.yaml #-}
-resolver: lts-17.0
-
-allow-newer: false
-
-packages:
-- .
-
-extra-deps: []
-
 {-# START_FILE LICENSE #-}
 Copyright {{author-name}}{{^author-name}}Author name here{{/author-name}} (c) {{year}}{{^year}}2019{{/year}}
 


### PR DESCRIPTION
This proposed pull request effectively ensures that `stack new ... github reanimate/plain` makes use of the latest LTS resolver from Stackage.

By removing the specification of `stack.yaml` in `plain.hsfiles`, this allows `stack new` to create its own `stack.yaml`, which will (automatically) include the latest LTS resolver.